### PR TITLE
Fixing “BACK button has no effect” issue

### DIFF
--- a/http2https.user.js
+++ b/http2https.user.js
@@ -74,5 +74,5 @@
           "\n"+
           "\nNew Location: "+new_location);
   };
-  location.href = new_location;
+  location.replace(new_location);
 })();


### PR DESCRIPTION
I suggest this small change that allows to replace the http URL by the https URL in browser’s `history`, thus limiting the issues with <kbd>BACK</kbd> button (which immediately goes FORWARD again and you end up on same page) and saving one duplicate line of display.
